### PR TITLE
Corrected git and volo address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # A Blank Template for Open Web Apps
 
 The is a minimal template that has a little HTML, CSS, and js to help
@@ -8,8 +7,8 @@ you start writing an Open Web App.
 
 There are a few ways to get this template:
 
-* git clone git://github.com/mozilla/mortar-list-detail.git myapp
-* volo create myapp mozilla/mortar-list-detail
+* git clone git://github.com/mozilla/mortar-app-stub.git myapp
+* volo create myapp mozilla/mortar-app-stub
 
 If you have node installed, you can run a development server with volo:
 


### PR DESCRIPTION
The addresses listed in README.md is for mortar-list-detail. Corrected them to be for mortar-app-stub instead.
