### PR TITLE
Fixed json parsing error in manifest file.

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -16,10 +16,10 @@
   "installs_allowed_from": ["*"],
   "locales": {
     "es": {
-      "description": "Tu nueva e impresionante Open Web App",
+      "description": "Tu nueva e impresionante Open Web App"
     },
     "it": {
-      "description": "Il vostro nuovo fantastico Open Web App",
+      "description": "Il vostro nuovo fantastico Open Web App"
     }
   },
   "default_locale": "en"


### PR DESCRIPTION
App manager was complaining about the extra comma when parsing the manifest.
